### PR TITLE
Auto change wallpaper

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,10 @@
             <div class="time" id="current-time"></div>
             <div class="info">
                 <center>
-                    <div id="quotes" style="width: 87%; line-height: 1.6;" </div>
+                        <div id="quotes" style="width: 87%; line-height: 1.6;">
+                        <h4 class="quote"></h4>
+                        <h5 class="credit" style='font-size:20px'></h5>
+                    </div>
                 </center>
                 <br><br>
                 <div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -55,9 +55,11 @@ function getQuotes() {
   fetch("https://quote-garden.herokuapp.com/quotes/random")
     .then((res) => res.json())
     .then((data) => {
+      document.querySelector('.quote').innerHTML = data.quoteText;
       document.querySelector(
-        "#quotes"
-      ).innerHTML = `<br><p><b style='font-size:23'>"${data.quoteText}"</b></p><div style='font-size:20'><i> by - ${data.quoteAuthor}</i></div>`;
+        ".credit"
+      ).innerHTML = `<i> by - ${data.quoteAuthor}</i></h5>`;
+      document.querySelector('#quotes').style.opacity = 1;
     });
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -63,12 +63,10 @@ function getQuotes() {
 
 function fetchImage() {
   const img = new Image();
-  document.getElementById("background-container").style.opacity = 0;
   img.onload = function () {
     document.getElementById(
       "background-container"
     ).style.backgroundImage = `url(${this.src})`;
-    document.getElementById("background-container").style.opacity = 1;
   };
 
   if (localStorage.getItem("image") === null) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -113,7 +113,7 @@ function unsplashGetPhotos() {
 
 chrome.alarms.create("ChangeWallpaper", {
   // delayInMinutes: 1.0,
-  periodInMinutes: 1,
+  periodInMinutes: 12*60,
 });
 
 chrome.alarms.onAlarm.addListener(unsplashGetPhotos);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -93,14 +93,16 @@ async function handleImageUrl(url){
 }
 
 
- function unsplashGetPhotos() {
-  fetch(`https://api.unsplash.com/photos/random${clientID}`)
+function unsplashGetPhotos() {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  fetch(`https://api.unsplash.com/photos/random${clientID}&w=${width}&h=${height}`)
     .then((res) => res.json())
     .then((data) => {
       localStorage.setItem("timestampFetched", Date.now());
       localStorage.setItem("name", data.user.name);
       localStorage.setItem("link", data.links.html);
-      handleImageUrl(data.urls.full);
+      handleImageUrl(data.urls.custom);
     })
     .catch((err) => {
       console.error(err);

--- a/styles/style.css
+++ b/styles/style.css
@@ -130,6 +130,16 @@ body {
 #quotes {
   text-align: center;
   color: #ddd3d3;
+  display: flex;
+  flex-direction: column;
+  min-height: 30vh;
+  opacity: 0;
+  -webkit-transition: opacity 0.5s;
+  transition: opacity 0.5s;
+}
+
+.quote{
+ font-size: 25px;
 }
 
 #change-btn {

--- a/styles/style.css
+++ b/styles/style.css
@@ -13,9 +13,8 @@ body {
   height: 100%;
   width: 100%;
   background-position: center;
-  opacity: 0;
-  -webkit-transition: opacity 0.5s;
-  transition: opacity 0.5s;
+  -webkit-transition: background-image 0.5s;
+  transition: background-image 0.5s;
 
 }
 


### PR DESCRIPTION
This PR implements the auto wallpaper change feature.

The fetching time is saved as a timestamp in localstorage, and it is compared to the current timestamp when a new tab is opened. Chrome alarm is also used in order to update the background every 12 hours, when the new tab is idle.

Moreover, it refactors the transition: Instead of JS, it transitions through css `transition: background-image 0.5s`.

Lastly, it sets a minimum height for the quote container, so the UI stays intact when a new quote is fetched.