### PR TITLE
Changed the link request to 'data.links.download'

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -128,7 +128,7 @@ function unsplashGetPhotos() {
     .then((data) => {
       localStorage.setItem("timestampFetched", Date.now());
       localStorage.setItem("name", data.user.name);
-      localStorage.setItem("link", data.links.html);
+      localStorage.setItem("link", `${data.links.download}?force=true`);
       handleImageUrl(data.urls.custom);
     })
     .catch((err) => {


### PR DESCRIPTION
Component: Updated the link on line 131 in the unsplashGetPhotos() function. 

When a user clicks on "Download Photo" it would re-direct the user to the unsplash website in order for them to download the photo. 

In order to solve the issue I read the docs located here: [https://help.unsplash.com/en/articles/2511258-guideline-triggering-a-download](https://help.unsplash.com/en/articles/2511258-guideline-triggering-a-download) 
Then went to the unsplash website to see how they allow users to download photos directly. 

Issue # [29](https://github.com/AmitGujar/Bink-Chrome-Extension/issues/29)

I tried to follow the contributing docs as much as possible so I apologize if there are any issues in this pull request.
Let me know if any issues and I will correct them as soon as possible. Thanks!